### PR TITLE
Prevent usage of both attr and bind-attr on a component's element

### DIFF
--- a/src/a1atscript/ng2Directives/PropertiesBuilder.js
+++ b/src/a1atscript/ng2Directives/PropertiesBuilder.js
@@ -1,19 +1,49 @@
 import BindBuilder from "./BindBuilder.js"
 
-var prefix = "___bindable___"
+const BIND_PREFIX = "_=_";
+const STRING_PREFIX = "_@_";
+
+const USING_DATA_BINDING = 1;
+const USING_RAW_STRING = 2;
 
 export default class PropertiesBuilder extends BindBuilder {
 
   setupProperty(key, properties) {
-    properties[key] = "@"+this._bindObj[key];
-    properties[prefix+key] = "=?bind"+this._bindObj[key][0].toUpperCase() + this._bindObj[key].slice(1);
-    Object.defineProperty(this._component.prototype, prefix+key, {
+    let using;
+
+    properties[STRING_PREFIX + key] = "@" + this._bindObj[key];
+    properties[BIND_PREFIX + key] = "=?bind" + this._bindObj[key][0].toUpperCase() + this._bindObj[key].slice(1);
+
+    // This property is used when user uses the `bind-property` attribute on a directive to bind an expression
+    Object.defineProperty(this._component.prototype, BIND_PREFIX + key, {
       enumerable: true,
       configurable: true,
-      set: function(value) {
+      set: genericSetter(USING_RAW_STRING, USING_DATA_BINDING)
+    });
+
+    // This property is used when user uses the `property` attribute on a directive to bind a string
+    Object.defineProperty(this._component.prototype, STRING_PREFIX + key, {
+      enumerable: true,
+      configurable: true,
+      set: genericSetter(USING_DATA_BINDING, USING_RAW_STRING)
+    });
+
+    function genericSetter(toExpect, toIgnore) {
+      return function(value) {
+        if (using === toIgnore) {
+          if (value !== undefined) {
+            throw new Error(`Cannot use bind-${key} and ${key} simultaneously`);
+          }
+          return;
+        }
+
+        if (value !== undefined) {
+          using = toExpect;
+        }
+
         this[key] = value;
       }
-    });
+    }
   }
 
 }

--- a/test/PropertiesBuilder_spec.js
+++ b/test/PropertiesBuilder_spec.js
@@ -19,16 +19,36 @@ describe("PropertiesBuilder", function() {
 
   it("should setup the correct properties", function() {
     expect(properties).toEqual({
-      "cheese": "@danish",
-      "___bindable___cheese": "=?bindDanish",
-      "apple": "@apple",
-      "___bindable___apple": "=?bindApple"
+      "_@_cheese": "@danish",
+      "_=_cheese": "=?bindDanish",
+      "_@_apple": "@apple",
+      "_=_apple": "=?bindApple"
     });
   });
 
-  it("should setup the setters", function() {
+  it("should setup the bind setter", function() {
     var component = new Component();
-    component.___bindable___apple = "value";
-    expect(component.apple).toEqual("value");
+    component["_=_apple"] = "bind";
+    expect(component.apple).toEqual("bind");
+  });
+
+  it("should setup the string setter", function() {
+    var component = new Component();
+    component["_@_apple"] = "string";
+    expect(component.apple).toEqual("string");
+  });
+
+  it("should disable string if bind is used first", function() {
+    var component = new Component();
+    component["_=_apple"] = "bind";
+    expect(() => component["_@_apple"] = "string").toThrow(new Error('Cannot use bind-apple and apple simultaneously'));
+    expect(component.apple).toEqual('bind');
+  });
+
+  it("should disable bind if string is used first", function() {
+    var component = new Component();
+    component["_@_apple"] = "string";
+    expect(() => component["_=_apple"] = "bind").toThrow(new Error('Cannot use bind-apple and apple simultaneously'));
+    expect(component.apple).toEqual('string');
   });
 });


### PR DESCRIPTION
This commit fixes an issue introduced by Angular 1.4.1 where using bind-attr attribute on a component element was overwritten with undefined by the unused non-bind attr.

Fixes #8 