### PR TITLE
Export symbols explicitly.

### DIFF
--- a/src/a1atscript.js
+++ b/src/a1atscript.js
@@ -1,8 +1,38 @@
-export * from './a1atscript/Injector.js';
-export * from './a1atscript/annotations.js';
-export * from './a1atscript/DirectiveObject.js';
+export {
+  registerInjector,
+  Injector
+} from './a1atscript/Injector.js';
+
+export {
+  Config,
+  Run,
+  Controller,
+  Directive,
+  Service,
+  Factory,
+  Provider,
+  Value,
+  Constant,
+  Filter,
+  Animation,
+  Module,
+  AsModule
+} from './a1atscript/annotations.js';
+
+export { DirectiveObject } from './a1atscript/DirectiveObject.js';
+
 import './a1atscript/ng2Directives/ComponentInjector.js';
-export * from "./a1atscript/ng2Directives/Component.js";
-export * from './a1atscript/ToAnnotation.js';
-export * from './a1atscript/bootstrap.js';
-export * from './a1atscript/Router.js';
+
+export {
+  Component,
+  Template,
+  BaseView,
+  View
+} from "./a1atscript/ng2Directives/Component.js";
+
+export { ToAnnotation } from './a1atscript/ToAnnotation.js';
+
+export { bootstrap } from './a1atscript/bootstrap.js';
+
+export { Router, RouteConfig } from './a1atscript/Router.js';
+

--- a/src/a1atscript/Router.js
+++ b/src/a1atscript/Router.js
@@ -1,7 +1,7 @@
 import {ComponentMapper} from "./router/ComponentMapper.js";
 import {RouteReader} from "./router/RouteReader.js";
-import {RouteInitializer} from "./router/RouteInitializer.js";
-export * from "./router/RouteConfig.js";
+import { RouteInitializer } from "./router/RouteInitializer.js";
+export { RouteConfig } from "./router/RouteConfig.js";
 
 var componentMapper = new ComponentMapper();
 var routeReader = new RouteReader(componentMapper);


### PR DESCRIPTION
This allows people to quickly look at and see what symbols your library provides.